### PR TITLE
Bugfix/188909786 notification url issues

### DIFF
--- a/Controller/Notification/Index.php
+++ b/Controller/Notification/Index.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace RicardoMartins\PagBank\Controller\Notifications;
+namespace RicardoMartins\PagBank\Controller\Notification;
 
 use Magento\Framework\Api\SearchCriteriaBuilder;
 use Magento\Framework\App\Action\Action;
@@ -96,7 +96,7 @@ class Index implements CsrfAwareActionInterface, HttpPostActionInterface
     {
         $order = null;
         $searchCriteria = $this->searchCriteriaBuilder->addFilter('txn_id', $transactionId)
-            ->addFilter(TransactionInterface::TXN_TYPE, TransactionInterface::TYPE_ORDER)
+            ->addFilter(TransactionInterface::TXN_TYPE, [TransactionInterface::TYPE_ORDER, TransactionInterface::TYPE_CAPTURE], 'in')
             ->create();
 
         try {

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "license": "GPL-3.0-or-later",
     "version": "4.4.2",
     "require": {
-        "php": "~8.1.0||~8.2.0",
+        "php": "~8.1.0||~8.2.0||~8.3.0",
         "magento/module-vault": "101.2.*"
     },
     "authors": [


### PR DESCRIPTION
* Renames the notification controller url to /notification (was /notifications) causing problems to receive order updates
    * Fixes a problem in the query that could not find some transactions/orders when dealing with credit card notifications (maybe other methods too).